### PR TITLE
Contracts: Use RuntimeUpgrade hooks instead of Hooks::on_runtime_upgr…

### DIFF
--- a/pallets/dmp-queue/src/lib.rs
+++ b/pallets/dmp-queue/src/lib.rs
@@ -139,10 +139,6 @@ pub mod pallet {
 
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
-		fn on_runtime_upgrade() -> Weight {
-			migration::migrate_to_latest::<T>()
-		}
-
 		fn on_idle(_now: T::BlockNumber, max_weight: Weight) -> Weight {
 			// on_idle processes additional messages with any remaining block weight.
 			Self::service_queue(max_weight)

--- a/pallets/dmp-queue/src/migration.rs
+++ b/pallets/dmp-queue/src/migration.rs
@@ -19,31 +19,34 @@
 use crate::{Config, Configuration, Overweight, Pallet, DEFAULT_POV_SIZE};
 use frame_support::{
 	pallet_prelude::*,
-	traits::StorageVersion,
+	traits::{OnRuntimeUpgrade, StorageVersion},
 	weights::{constants::WEIGHT_REF_TIME_PER_MILLIS, Weight},
 };
 
 /// The current storage version.
-pub const STORAGE_VERSION: StorageVersion = StorageVersion::new(1);
+pub const STORAGE_VERSION: StorageVersion = StorageVersion::new(2);
 
-/// Migrates the pallet storage to the most recent version, checking and setting the
-/// `StorageVersion`.
-pub fn migrate_to_latest<T: Config>() -> Weight {
-	let mut weight = T::DbWeight::get().reads(1);
+/// Migrates the pallet storage to the most recent version.
+pub struct Migration<T: Config>(PhantomData<T>);
 
-	if StorageVersion::get::<Pallet<T>>() == 0 {
-		weight.saturating_accrue(migrate_to_v1::<T>());
-		StorageVersion::new(1).put::<Pallet<T>>();
-		weight.saturating_accrue(T::DbWeight::get().writes(1));
+impl<T: Config> OnRuntimeUpgrade for Migration<T> {
+	fn on_runtime_upgrade() -> Weight {
+		let mut weight = T::DbWeight::get().reads(1);
+
+		if StorageVersion::get::<Pallet<T>>() == 0 {
+			weight.saturating_accrue(migrate_to_v1::<T>());
+			StorageVersion::new(1).put::<Pallet<T>>();
+			weight.saturating_accrue(T::DbWeight::get().writes(1));
+		}
+
+		if StorageVersion::get::<Pallet<T>>() == 1 {
+			weight.saturating_accrue(migrate_to_v2::<T>());
+			StorageVersion::new(2).put::<Pallet<T>>();
+			weight.saturating_accrue(T::DbWeight::get().writes(1));
+		}
+
+		weight
 	}
-
-	if StorageVersion::get::<Pallet<T>>() == 1 {
-		weight.saturating_accrue(migrate_to_v2::<T>());
-		StorageVersion::new(2).put::<Pallet<T>>();
-		weight.saturating_accrue(T::DbWeight::get().writes(1));
-	}
-
-	weight
 }
 
 mod v0 {

--- a/pallets/parachain-system/src/lib.rs
+++ b/pallets/parachain-system/src/lib.rs
@@ -57,7 +57,7 @@ use sp_runtime::{
 use sp_std::{cmp, collections::btree_map::BTreeMap, prelude::*};
 use xcm::latest::XcmHash;
 
-mod migration;
+pub mod migration;
 mod relay_state_snapshot;
 #[macro_use]
 pub mod validate_block;
@@ -197,10 +197,6 @@ pub mod pallet {
 
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
-		fn on_runtime_upgrade() -> Weight {
-			migration::on_runtime_upgrade::<T>()
-		}
-
 		fn on_finalize(_: T::BlockNumber) {
 			<DidSetValidationCode<T>>::kill();
 			<UpgradeRestrictionSignal<T>>::kill();

--- a/pallets/xcmp-queue/src/lib.rs
+++ b/pallets/xcmp-queue/src/lib.rs
@@ -115,10 +115,6 @@ pub mod pallet {
 
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
-		fn on_runtime_upgrade() -> Weight {
-			migration::migrate_to_latest::<T>()
-		}
-
 		fn on_idle(_now: T::BlockNumber, max_weight: Weight) -> Weight {
 			// on_idle processes additional messages with any remaining block weight.
 			Self::service_xcmp_queue(max_weight)

--- a/pallets/xcmp-queue/src/migration.rs
+++ b/pallets/xcmp-queue/src/migration.rs
@@ -19,31 +19,34 @@
 use crate::{Config, Overweight, Pallet, QueueConfig, DEFAULT_POV_SIZE};
 use frame_support::{
 	pallet_prelude::*,
-	traits::StorageVersion,
+	traits::{OnRuntimeUpgrade, StorageVersion},
 	weights::{constants::WEIGHT_REF_TIME_PER_MILLIS, Weight},
 };
 
 /// The current storage version.
-pub const STORAGE_VERSION: StorageVersion = StorageVersion::new(2);
+pub const STORAGE_VERSION: StorageVersion = StorageVersion::new(3);
 
-/// Migrates the pallet storage to the most recent version, checking and setting the
-/// `StorageVersion`.
-pub fn migrate_to_latest<T: Config>() -> Weight {
-	let mut weight = T::DbWeight::get().reads(1);
+/// Migrates the pallet storage to the most recent version.
+pub struct Migration<T: Config>(PhantomData<T>);
 
-	if StorageVersion::get::<Pallet<T>>() == 1 {
-		weight.saturating_accrue(migrate_to_v2::<T>());
-		StorageVersion::new(2).put::<Pallet<T>>();
-		weight.saturating_accrue(T::DbWeight::get().writes(1));
+impl<T: Config> OnRuntimeUpgrade for Migration<T> {
+	fn on_runtime_upgrade() -> Weight {
+		let mut weight = T::DbWeight::get().reads(1);
+
+		if StorageVersion::get::<Pallet<T>>() == 1 {
+			weight.saturating_accrue(migrate_to_v2::<T>());
+			StorageVersion::new(2).put::<Pallet<T>>();
+			weight.saturating_accrue(T::DbWeight::get().writes(1));
+		}
+
+		if StorageVersion::get::<Pallet<T>>() == 2 {
+			weight.saturating_accrue(migrate_to_v3::<T>());
+			StorageVersion::new(3).put::<Pallet<T>>();
+			weight.saturating_accrue(T::DbWeight::get().writes(1));
+		}
+
+		weight
 	}
-
-	if StorageVersion::get::<Pallet<T>>() == 2 {
-		weight.saturating_accrue(migrate_to_v3::<T>());
-		StorageVersion::new(3).put::<Pallet<T>>();
-		weight.saturating_accrue(T::DbWeight::get().writes(1));
-	}
-
-	weight
 }
 
 mod v1 {


### PR DESCRIPTION
This MR is cherry-picked from the parity project to solve the try-runtime errors. However, the code for the parachain template wasn't introduced here.

```
commit 1208a9d43f371db704ff985252bf4b113ea2bff0
Author: PG Herveou <pgherveou@gmail.com>
Date:   Mon Jun 5 13:56:55 2023 +0200

    Contracts: Use RuntimeUpgrade hooks instead of Hooks::on_runtime_upgrade (#2570)

* Fixes

* Remove on_runtime_upgrade hook

* remove upgrade_fn / add doc to Migration struct

* Add cumulus_pallet_*::migration to Migrations type

* add docstring

* fix

* Update parachain-template/runtime/src/lib.rs



* Update parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/lib.rs

* Update pallets/parachain-system/src/migration.rs

---------
```